### PR TITLE
Fix for  processing `failed` status in BuildScanner

### DIFF
--- a/src/main/java/com/acunetix/BuildScanner.java
+++ b/src/main/java/com/acunetix/BuildScanner.java
@@ -103,6 +103,7 @@ public class BuildScanner extends hudson.tasks.Builder implements SimpleBuildSte
         final String SCHEDULED = "scheduled";
         final String QUEUED = "queued";
         final String NOREPORT = "no_report";
+        final String FAILED = "failed";
         final PrintStream listenerLogger = listener.getLogger();
 
         Engine engine = new Engine(getDescriptor().getgApiUrl(), getDescriptor().getgApiKey());
@@ -149,6 +150,12 @@ public class BuildScanner extends hudson.tasks.Builder implements SimpleBuildSte
                     scanAbortedExternally = true;
                     listenerLogger.println(SR.getString("aborting.the.build"));
                     throw new hudson.AbortException(SR.getString("scan.aborted.outside"));
+                }
+
+                if (scanStatus.equals(FAILED)) {
+                    scanAbortedExternally = true;
+                    listenerLogger.println(SR.getString("scan.failed"));
+                    throw new hudson.AbortException(SR.getString("scan.failed"));                    
                 }
 
                 scanThreat = engine.getScanThreat(scanId);

--- a/src/main/resources/Messages.properties
+++ b/src/main/resources/Messages.properties
@@ -11,6 +11,7 @@ scan.aborted.outside=The scan was aborted outside of this instance
 scan.aborted=The scan was aborted
 scan.completed=The scan was completed
 scan.scheduled=The scan was scheduled. Please ensure the configured scan can run immediately
+scan.failed=The scan was failed
 abort.scan.scheduled=The build was aborted because the scan is scheduled
 aborting.the.build=Aborting the build
 build.aborted=The build was aborted


### PR DESCRIPTION
This fix provide processing `Failed` status  from Acunetix of running a scan.

**Bug**: This behavior is currently not processed and `Jenkins job` hangs (with infinite loop).

_P.S: Please open issue tracker for this repo - if you want receive help from community :)_